### PR TITLE
Fix 'setup.py build' when encountering a dangling symlink

### DIFF
--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -113,7 +113,7 @@ def _get_build_extension_method(base, root):
             root_path = os.path.join(tempdir, 'src', root)
             # Make everything but the last directory (copytree interface)
             os.makedirs(os.path.dirname(root_path))
-            shutil.copytree('.', root_path)
+            shutil.copytree('.', root_path, symlinks=True)
             pkg_path = os.path.join(root_path, main_dir)
 
             env = {str('GOPATH'): tempdir}

--- a/testing/dangling_symlink/dangling
+++ b/testing/dangling_symlink/dangling
@@ -1,0 +1,1 @@
+does_not_exist

--- a/testing/dangling_symlink/fake.go
+++ b/testing/dangling_symlink/fake.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/testing/dangling_symlink/setup.py
+++ b/testing/dangling_symlink/setup.py
@@ -1,0 +1,13 @@
+from setuptools import Extension
+from setuptools import setup
+
+
+setup(
+    name='fake',
+    ext_modules=[Extension('fake', ['fake.go'])],
+    build_golang={'root': 'github.com/asottile/fake'},
+    # Would do this, but we're testing *our* implementation and this would
+    # install from pypi.  We can rely on setuptools-golang being already
+    # installed under test.
+    # setup_requires=['setuptools-golang'],
+)

--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -138,3 +138,8 @@ def test_integration_internal_imports(venv):
     run(venv.pip, 'install', os.path.join('testing', 'internal_imports'))
     out = run_output(venv.python, '-c', OHAI)
     assert out == 'ohai, Anthony\n'
+
+
+def test_regression_dangling_symlink(venv):
+    # this raises an error because of a dangling symlink
+    run(venv.pip, 'install', os.path.join('testing', 'dangling_symlink'))


### PR DESCRIPTION
Hello,

setup.py build fails, when there is a dangling symlink present.

Steps to reproduce:
```bash
cd setuptools-golang-examples 
ln -sf does_not_exist dangling 
DISTUTILS_DEBUG=1 python3 setup.py build
```
fails with
```
running build
Distribution.get_command_obj(): creating 'build' command object
running build_ext
Distribution.get_command_obj(): creating 'build_ext' command object
error: [('./dangling', '/tmp/tmpr3jqtkp5/src/github.com/asottile/setuptools-golang-examples/dangling', "[Errno 2] No such file or directory: './dangling'")]
Traceback (most recent call last):
  File "setup.py", line 30, in <module>
    setup_requires=['setuptools-golang>=0.2.0'],
  File "/usr/lib/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.5/distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/usr/lib/python3.5/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/build_ext.py", line 49, in run
    _build_ext.run(self)
  File "/usr/lib/python3.5/distutils/command/build_ext.py", line 338, in run
    self.build_extensions()
  File "/usr/lib/python3.5/distutils/command/build_ext.py", line 447, in build_extensions
    self._build_extensions_serial()
  File "/usr/lib/python3.5/distutils/command/build_ext.py", line 472, in _build_extensions_serial
    self.build_extension(ext)
  File "/tmp/setuptools-golang-examples/.eggs/setuptools_golang-1.3.0-py3.5.egg/setuptools_golang.py", line 116, in build_extension
    shutil.copytree('.', root_path)
  File "/usr/lib/python3.5/shutil.py", line 353, in copytree
    raise Error(errors)
shutil.Error: [('./dangling', '/tmp/tmpr3jqtkp5/src/github.com/asottile/setuptools-golang-examples/dangling', "[Errno 2] No such file or directory: './dangling'")]
```

Best regards
Jonathan