### PR TITLE
Updates for go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 matrix:
     include:
-        -   env: TOXENV=py27 GO=1.9
         -   env: TOXENV=py27 GO=1.10
-        -   env: TOXENV=py35 GO=1.10
-            python: 3.5
-        -   env: TOXENV=py36 GO=1.10
+        -   env: TOXENV=py27 GO=1.11
+        -   env: TOXENV=py36 GO=1.11
             python: 3.6
-        -   env: TOXENV=pypy GO=1.10
+        -   env: TOXENV=pypy GO=1.11
             python: pypy
 install:
     - eval "$(gimme $GO)"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A setuptools extension for building cpython extensions written in golang.
 
 ## Requirements
 
-This requires golang >= 1.5.  It is currently tested against 1.9 and 1.10.
+This requires golang >= 1.5.  It is currently tested against 1.10 and 1.11.
 
-This requires python >= 2.7.  It is currently tested against 2.7, 3.5, 3.6,
+This requires python >= 2.7.  It is currently tested against 2.7, 3.6, 3.7,
 and pypy.
 
 ## Platform Support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
     -   PYTHON: 'C:\Python37'
 
 install:
--   'SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\bin;C:\go110-x86\bin;%PATH%'
--   'SET GOROOT=C:\go110-x86'
+-   'SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\MinGW\bin;C:\go-x86\bin;%PATH%'
+-   'SET GOROOT=C:\go-x86'
 -   'pip install pytest'
 
 # Not a C# project

--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -150,8 +150,6 @@ GOLANG = 'https://storage.googleapis.com/golang/go{}.linux-amd64.tar.gz'
 SCRIPT = '''\
 cd /tmp
 curl {golang} --silent --location | tar -xz
-# TODO: GOROOT is only needed for go<=1.8
-export GOROOT=/tmp/go
 export PATH="$GOROOT/bin:$PATH"
 for py in {pythons}; do
     "/opt/python/$py/bin/pip" wheel --no-deps --wheel-dir /tmp /dist/*.tar.gz
@@ -164,7 +162,7 @@ ls -al /dist
 def build_manylinux_wheels(argv=None):  # pragma: no cover
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--golang', default='1.10',
+        '--golang', default='1.11',
         help='Override golang version (default %(default)s)',
     )
     parser.add_argument(


### PR DESCRIPTION
- drops support for go<1.9 (unsupported by go upstream) in the manylinux wheel builder