### PR TITLE
Fix clean up of downloaded modules when using go.mod

### DIFF
--- a/testing/gomodules/go.mod
+++ b/testing/gomodules/go.mod
@@ -1,0 +1,5 @@
+module github.com/asottile/setuptools-golang/testing/gomodules
+
+go 1.14
+
+require github.com/golang/example v0.0.0-20170904185048-46695d81d1fa

--- a/testing/gomodules/go.sum
+++ b/testing/gomodules/go.sum
@@ -1,0 +1,2 @@
+github.com/golang/example v0.0.0-20170904185048-46695d81d1fa h1:iqCQC2Z53KkwGgTN9szyL4q0OQHmuNjeoNnMT6lk66k=
+github.com/golang/example v0.0.0-20170904185048-46695d81d1fa/go.mod h1:tO/5UvQ/uKigUjQBPqzstj6uxd3fUIjddi19DxGJeWg=

--- a/testing/gomodules/reversemsg.go
+++ b/testing/gomodules/reversemsg.go
@@ -1,0 +1,19 @@
+package main
+
+// #include <Python.h>
+import "C"
+
+import (
+	"fmt"
+
+	"github.com/golang/example/stringutil"
+)
+
+//export reversemsg
+func reversemsg() *C.PyObject {
+	fmt.Print(stringutil.Reverse("elpmaxe tset"))
+
+	return C.Py_None
+}
+
+func main() {}

--- a/testing/gomodules/reversemsg_support.go
+++ b/testing/gomodules/reversemsg_support.go
@@ -1,0 +1,29 @@
+package main
+
+// #include <Python.h>
+//
+// PyObject* reversemsg();
+//
+// static struct PyMethodDef methods[] = {
+//     {"reversemsg", (PyCFunction)reversemsg, METH_NOARGS},
+//     {NULL, NULL}
+// };
+//
+// #if PY_MAJOR_VERSION >= 3
+// static struct PyModuleDef module = {
+//     PyModuleDef_HEAD_INIT,
+//     "gomodules",
+//     NULL,
+//     -1,
+//     methods
+// };
+//
+// PyMODINIT_FUNC PyInit_gomodules(void) {
+//     return PyModule_Create(&module);
+// }
+// #else
+// PyMODINIT_FUNC initgomodules(void) {
+//     Py_InitModule3("gomodules", methods, NULL);
+// }
+// #endif
+import "C"

--- a/testing/gomodules/setup.py
+++ b/testing/gomodules/setup.py
@@ -1,0 +1,15 @@
+from setuptools import Extension
+from setuptools import setup
+
+
+setup(
+    name='gomod',
+    ext_modules=[Extension('gomodules', ['reversemsg.go'])],
+    build_golang={
+        'root': 'github.com/asottile/setuptools-golang/testing/gomodules',
+    },
+    # Would do this, but we're testing *our* implementation and this would
+    # install from pypi.  We can rely on setuptools-golang being already
+    # installed under test.
+    # setup_requires=['setuptools-golang'],
+)

--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -103,6 +103,15 @@ def test_integration_imports_gh(venv):
     assert out == '\x1b[0;31mohai\x1b[0m\n'
 
 
+GOMOD = 'import gomodules; gomodules.reversemsg()'
+
+
+def test_integration_gomodules(venv):
+    run(venv.pip, 'install', os.path.join('testing', 'gomodules'))
+    out = run_output(venv.python, '-c', GOMOD)
+    assert out == 'test example'
+
+
 def test_integration_notfound(venv):
     ret = run(
         venv.pip, 'install', os.path.join('testing', 'notfound'),


### PR DESCRIPTION
Projects that use go.mod will result in the build downloading the
modules to an temporary path. Golang introduced read only directories to
protect the generated module cache from accidental writes, resulting in
failures to build when exiting the temporary directory context.

Adapt the solution from pre-commit to make the directory and file
writable on removal and include a rudimentary test that exercises
download via a simple example module hosted by the golang org in github.

Fixes #49
