### PR TITLE
Include normal reset byte in test assertion

### DIFF
--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -100,7 +100,7 @@ RED = 'import red; print(red.red(u"ohai"))'
 def test_integration_imports_gh(venv):
     run(venv.pip, 'install', os.path.join('testing', 'imports_gh'))
     out = run_output(venv.python, '-c', RED)
-    assert out == '\x1b[31mohai\x1b[0m\n'
+    assert out == '\x1b[0;31mohai\x1b[0m\n'
 
 
 def test_integration_notfound(venv):


### PR DESCRIPTION
Test for coloured output will fail due to a mismatch between what is
generated and what is asserted. The generated output will contain a byte
to set console output to normal before subsequently modifying it to be
coloured red at normal intensity. Update the assertion to match.
