### PR TITLE
Update golang used in CI to supported versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,17 +18,17 @@ jobs:
   parameters:
     toxenvs: [py38]
     os: linux
-    name_postfix: _go_1_12
+    name_postfix: _go_1_14
     pre_test:
     - task: GoTool@0
       inputs:
-        version: '1.12.17'
+        version: '1.14.8'
 - template: job--python-tox.yml@asottile
   parameters:
     toxenvs: [pypy3, py36, py37, py38]
     os: linux
-    name_postfix: _go_1_13
+    name_postfix: _go_1_15
     pre_test:
     - task: GoTool@0
       inputs:
-        version: '1.13.8'
+        version: '1.15.1'

--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -188,7 +188,7 @@ def build_manylinux_wheels(
 ) -> int:  # pragma: no cover
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--golang', default='1.13.8',
+        '--golang', default='1.14.8',
         help='Override golang version (default %(default)s)',
     )
     parser.add_argument(


### PR DESCRIPTION
Golang 1.12 & 1.13 are no longer supported, update to golang 1.15 &
1.14.

Only the 2 most recent minor releases are supported at a time for
golang.
