### PR TITLE
Allow user override of GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ duplicate symbol _PyDockerfile_GoParseError in:
 Make sure to mark global variables defined in C as `extern`.
 [Here's an example PR](https://github.com/asottile/dockerfile/pull/8)
 
+### repeated rebuilds can be slow
+
+setuptools-golang attempts to make builds more repeatable by using a separate
+`GOPATH` -- if you'd like to reuse a GOPATH you can set the
+`SETUPTOOLS_GOLANG_GOPATH` environment variable:
+
+```console
+$ SETUPTOOLS_GOLANG_GOPATH=~/go pip install .
+...
+```
+
 ## Building manylinux wheels
 
 `setuptools-golang` also provides a tool for building

--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -149,7 +149,8 @@ def _get_build_extension_method(
             shutil.copytree('.', root_path, symlinks=True)
             pkg_path = os.path.join(root_path, main_dir)
 
-            env = {'GOPATH': tempdir}
+            gopath = os.environ.get('SETUPTOOLS_GOLANG_GOPATH', tempdir)
+            env = {'GOPATH': gopath}
             cmd_get = ('go', 'get', '-d')
             _check_call(cmd_get, cwd=pkg_path, env=env)
 

--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import shlex
 import subprocess
 import sys
 
@@ -143,6 +144,21 @@ def test_integration_internal_imports(venv):
     run(venv.pip, 'install', os.path.join('testing', 'internal_imports'))
     out = run_output(venv.python, '-c', OHAI)
     assert out == 'ohai, Anthony\n'
+
+
+def test_integration_user_gopath(venv, tmpdir):
+    testdir = os.path.join('testing', 'gomodules')
+
+    gopath = str(tmpdir.join('gopath'))
+    env = {**os.environ, 'SETUPTOOLS_GOLANG_GOPATH': gopath}
+    ret = run(
+        venv.pip, 'install', '-v', testdir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert f"$ GOPATH={shlex.quote(gopath)} go get -d" in ret.out
 
 
 def test_integration_defines(venv):


### PR DESCRIPTION
Repeat building for developers can benefit from being able to shortcut
full executions through cache reuse. Allow user to override the GOPATH
used by specifying a module specific environment variable. This can
allow a user to reuse a pre-populated golang module and build cache for
faster compiles when developing.

Note it requires a valid gomodule package, therefore re-using the
gomodules test to validate that the GOPATH is modified.

Local testing indicates that for a module in a custom project the
install time could be reduced from 35 seconds to 9 seconds. While not
perfect, it is still useful for local development environments,
especially if more modules are used.
