### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A setuptools extension for building cpython extensions written in golang.
 
 This requires golang >= 1.5.  It is currently tested against 1.16 and 1.17.
 
-This requires python >= 3.6.  It is currently tested against python3 and pypy3.
+This requires python >= 3.7.  It is currently tested against python3 and pypy3.
 
 ## Platform Support
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
@@ -24,7 +24,7 @@ jobs:
         version: '1.16.8'
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux
     name_postfix: _go_1_17
     pre_test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -23,7 +22,7 @@ classifiers =
 
 [options]
 py_modules = setuptools_golang
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/testing/dangling_symlink/setup.py
+++ b/testing/dangling_symlink/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/defines/setup.py
+++ b/testing/defines/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/gomodules/setup.py
+++ b/testing/gomodules/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/imports_gh/setup.py
+++ b/testing/imports_gh/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/internal_imports/setup.py
+++ b/testing/internal_imports/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/multidir/setup.py
+++ b/testing/multidir/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/notfound/setup.py
+++ b/testing/notfound/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/project_with_c/setup.py
+++ b/testing/project_with_c/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup

--- a/testing/sum/setup.py
+++ b/testing/sum/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/sum_pure_go/setup.py
+++ b/testing/sum_pure_go/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import setup
 

--- a/testing/sum_sub_package/setup.py
+++ b/testing/sum_sub_package/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup

--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import os
 import shlex

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos