### PR TITLE
Exp/upgrade manylinux

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = setuptools_golang
-version = 2.7.0
+version = 3.0.0
 description = A setuptools extension for building cpython extensions written in golang.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = setuptools_golang
-version = 3.0.0
+version = 2.7.0
 description = A setuptools extension for building cpython extensions written in golang.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -231,7 +231,7 @@ def build_manylinux_wheels(
             'docker', 'run', '--rm',
             '--volume', f'{os.path.abspath("dist")}:/dist:rw',
             '--user', f'{os.getuid()}:{os.getgid()}',
-            'quay.io/pypa/manylinux1_x86_64:latest',
+            'quay.io/pypa/manylinux2010_x86_64:latest',
             'bash', '-o', 'pipefail', '-euxc',
             SCRIPT.format(golang=golang, pythons=pythons),
         ),


### PR DESCRIPTION
Upgrade major vrsionas this deprecate older pip versions as deprecates manlinux1 in favour of manylinux2010 which means pip >= 19.0 which means minimum python of 3.7.3+, 3.8.0+

See https://github.com/pypa/manylinux for details