### PR TITLE
Pipe stdout and stderr to devnull while doing ldflag checks

### DIFF
--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -89,7 +89,10 @@ def _get_ldflags() -> str:
 
         for lflag in LFLAGS:  # pragma: no cover (platform specific)
             try:
-                subprocess.check_call((cc, testf, lflag), cwd=tmpdir)
+                subprocess.check_call(
+                    (cc, testf, lflag), cwd=tmpdir,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
                 return lflag
             except subprocess.CalledProcessError:
                 pass


### PR DESCRIPTION
Fixes #48 by simply piping stderr and stdout to /dev/null.