### PR TITLE
Add way for user to manually provide extra c&ld flags

### DIFF
--- a/setuptools_golang.py
+++ b/setuptools_golang.py
@@ -189,12 +189,12 @@ def _get_build_ext_cls(
 ) -> type[_build_ext]:
     attrs = {
         'build_extension': _get_build_extension_method(
-                base, 
-                root, 
-                strip, 
-                extra_cflags, 
-                extra_ldflags
-            )
+            base,
+            root,
+            strip,
+            extra_cflags,
+            extra_ldflags,
+        ),
     }
     return type('build_ext', (base,), attrs)
 

--- a/testing/sum_flag/go.mod
+++ b/testing/sum_flag/go.mod
@@ -1,0 +1,3 @@
+module github.com/asottile/fake
+
+go 1.16

--- a/testing/sum_flag/setup.py
+++ b/testing/sum_flag/setup.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from setuptools import Extension
+from setuptools import setup
+
+
+setup(
+    name='sum_flag',
+    ext_modules=[Extension('sum_flag', ['sum.go'])],
+    build_golang={'root': 'github.com/asottile/fake', "extra_cflags":"-O3", "extra_ldflags":"-ldl"},
+    # Would do this, but we're testing *our* implementation and this would
+    # install from pypi.  We can rely on setuptools-golang being already
+    # installed under test.
+    # setup_requires=['setuptools-golang'],
+)

--- a/testing/sum_flag/setup.py
+++ b/testing/sum_flag/setup.py
@@ -7,7 +7,11 @@ from setuptools import setup
 setup(
     name='sum_flag',
     ext_modules=[Extension('sum_flag', ['sum.go'])],
-    build_golang={'root': 'github.com/asottile/fake', "extra_cflags":"-O3", "extra_ldflags":"-ldl"},
+    build_golang={
+        'root': 'github.com/asottile/fake',
+        'extra_cflags': '-O3',
+        'extra_ldflags': '-ldl',
+    },
     # Would do this, but we're testing *our* implementation and this would
     # install from pypi.  We can rely on setuptools-golang being already
     # installed under test.

--- a/testing/sum_flag/sum.c
+++ b/testing/sum_flag/sum.c
@@ -1,0 +1,26 @@
+#include <Python.h>
+
+/* Will come from go */
+PyObject* sum(PyObject* , PyObject*);
+
+/* To shim go's missing variadic function support */
+int PyArg_ParseTuple_ll(PyObject* args, long* a, long* b) {
+    return PyArg_ParseTuple(args, "ll", a, b);
+}
+
+static struct PyMethodDef methods[] = {
+    {"sum", (PyCFunction)sum, METH_VARARGS},
+    {NULL, NULL}
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "sum_flag",
+    NULL,
+    -1,
+    methods
+};
+
+PyMODINIT_FUNC PyInit_sum_flag(void) {
+    return PyModule_Create(&module);
+}

--- a/testing/sum_flag/sum.go
+++ b/testing/sum_flag/sum.go
@@ -1,0 +1,17 @@
+package main
+
+// #include <Python.h>
+// int PyArg_ParseTuple_ll(PyObject*, long*, long*);
+import "C"
+
+//export sum
+func sum(self *C.PyObject, args *C.PyObject) *C.PyObject {
+	var a C.long
+	var b C.long
+	if C.PyArg_ParseTuple_ll(args, &a, &b) == 0 {
+		return nil
+	}
+	return C.PyLong_FromLong(a + b)
+}
+
+func main() {}

--- a/tests/setuptools_golang_test.py
+++ b/tests/setuptools_golang_test.py
@@ -77,6 +77,7 @@ SUM = 'import {0}; print({0}.sum(1, 2))'
     ('pkg', 'mod'),
     (
         (os.path.join('testing', 'sum'), 'sum'),
+        (os.path.join('testing', 'sum_flag'), 'sum_flag'),
         (os.path.join('testing', 'sum_pure_go'), 'sum_pure_go'),
         (os.path.join('testing', 'sum_sub_package'), 'sum_sub_package.sum'),
     ),


### PR DESCRIPTION
Hello, 

This is my first PR into this repo so please let me know if I've done something incorrect. I added test cases, formatted my code, and ensured `tox` passes locally.

---

This PR adds a way for an end-user to add special CFLAG or LDFLAG arguments to the go build phase. This allows the user to customize the flags based on various environmental notes which is not possible with the current comment/cgo system.